### PR TITLE
Config

### DIFF
--- a/src/ChangeModel.js
+++ b/src/ChangeModel.js
@@ -3,13 +3,11 @@
  */
 
 import axios from 'axios';
-
-const API_URI = 'http://localhost:8090/api/';
-const ASSETS_URI = 'http://localhost:8090/';
+import config from './config'
 
 let Axios = axios.create({
-    baseURL: API_URI,
-    timeout: 60000,
+    baseURL: config.API_ENDPOINT_URI,
+    timeout: 120000,
     responseType: 'json'
 })
 
@@ -81,7 +79,7 @@ function exportAsset(changeId, assetType) {
 
 function getAssetUri(relativePath) {
 
-    return [ASSETS_URI, relativePath].join('')
+    return [config.ASSETS_URI, relativePath].join('')
 }
 
 export default {

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,8 @@
+/**
+ * Created by dima on 18.11.16.
+ */
+
+export default {
+    API_ENDPOINT_URI: [process.env.REACT_APP_API_URI || 'http://localhost:8090', 'api' ].join('/'),
+    ASSETS_URI: process.env.REACT_APP_API_URI || 'http://localhost:8090'
+}


### PR DESCRIPTION
Using ```create-react-app``` feature – env variable injector – define the default (local development ) URIs in ```config.js``` and overwrite them with ```REACT_APP_API_URI```  var